### PR TITLE
Modification of start-iked.sh to allow sitename filename longer than …

### DIFF
--- a/start-iked.sh
+++ b/start-iked.sh
@@ -39,6 +39,10 @@ iked -F &
 IKED_PID=$!
 echo "IKEd started."
 
+#Modification to take into account that some site files are not opened using cwd due to their filename being longer than 6 caracters - JohanD (See Issue 1)
+/bin/mkdir /root/.ike
+/bin/ln /sites/ /root/.ike/sites -s
+
 echo "Starting IKEc for $SITE..."
 $COMMAND &
 IKEC_PID=$!


### PR DESCRIPTION
When not using this method the ikec keeps failing to open the **$SITE** file if filename is longer than 6 caracters..

Solution is to create /root/.ike and create symbolic link from /root/.ike/sites to /sites

**Listing of file in /sites :**
```
DEBUG ::: Listing files in /sites
total 12
drwx------ 2 1000 users 4096 Jan  4 15:19 .
drwxr-xr-x 1 root root  4096 Jan  4 15:24 ..
-rw-r--r-- 1 1000 users 3040 Jan  4 12:54 admin_long
DEBUG ::: End of listing of files in /sites
```

**Strace (before):** 
```
open("/root/.ike/sites/admin_long", O_RDONLY) = -1 ENOENT (No such file or directory)
open("admin_long\250\223\352\177", O_RDONLY) = -1 ENOENT (No such file or directory)
write(1, "!! : failed to load 'admin_long'"..., 33!! : failed to load 'admin_long'
) = 33
^CDetected SIGTERM, shuting down...
```

**Strace (after):**
```
open("/root/.ike/sites/admin_long", O_RDONLY) = 7
read(7, "n:version:4\ns:network-host:xxxx"..., 4096) = 3040
read(7, "", 4096)                       = 0
close(7)                                = 0
write(1, ">> : config loaded for site 'adm"..., 41>> : config loaded for site 'admin_long'
) = 41
>> : attached to key daemon ...
```

